### PR TITLE
feat: add new local provider skeleton

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,12 +1,23 @@
 from fastapi import FastAPI
 
-from searcher.provider import openlibrary as provider
-
 
 app = FastAPI()
 
 
 @app.get("/api/v1/books")
-def books(isbn):
+def books(isbn, provider_name):
+    """
+    Endpoint /api/v1/books?isbn=1&provider_name=XXX
+    """
+
+    provider = None
+
+    if provider_name == "openbooks":
+        from searcher.provider import openlibrary as provider
+    elif provider_name == "muse":
+        from searcher.provider import local as provider
+    else:
+        return {"error": "no provider specified"}
+
     result = provider.search_book(isbn)
     return {"response": result}

--- a/searcher/provider/local.py
+++ b/searcher/provider/local.py
@@ -1,0 +1,2 @@
+def search_book(isbn):
+    pass


### PR DESCRIPTION
This PR implements a provider skeleton for our internal provider "Muse"
First iteration for issue: #3 

Examples:

```
Request:
GET http://127.0.0.1:8000/api/v1/books?isbn=1&provider_name=muse
(Not implemented yet)
Response:
{"response":null}
```

```
Request:
GET http://127.0.0.1:8000/api/v1/books?isbn=1&provider_name=openbooks

Response:
{"response":[{"title":"he restores my soul"},{"title":"1"},{"title":"1111"},{"title":"+/2>"},{"title":"Auaction"},{"title":"A French Restoration"}]}
```

```
Request:
GET http://127.0.0.1:8000/api/v1/books?isbn=1

Response:
{"detail":[{"type":"missing","loc":["query","provider_name"],"msg":"Field required","input":null,"url":"https://errors.pydantic.dev/2.7/v/missing"}]}
```